### PR TITLE
Aldric : parsing d'expression fonctionnel

### DIFF
--- a/src/process/builders/ThompsonAutomatonBuilder.java
+++ b/src/process/builders/ThompsonAutomatonBuilder.java
@@ -1,0 +1,75 @@
+package process.builders;
+
+import java.util.Stack;
+
+import data.Automaton;
+
+/**
+ * Builder class that takes an expression (String) and creates an automaton with
+ * it.
+ * 
+ * @author Aldric Vitali Silvestre <aldric.vitali@outlook.fr>
+ */
+public class ThompsonAutomatonBuilder {
+	private String expression;
+
+	/**
+	 * Create an instance of the builder, that will do a fast check on the
+	 * expression given.
+	 * 
+	 * @param expression the expression to parse
+	 * @throws IllegalArgumentException if the expression is not valid
+	 */
+	public ThompsonAutomatonBuilder(String expression) throws IllegalArgumentException {
+		this.expression = expression;
+		checkExpression();
+	}
+
+	private void checkExpression() throws IllegalArgumentException {
+		/*
+		 * We will check if expression contains the same number of '(' and ')'
+		 */
+		int parenthesisWeight = 0;
+		char previousCharacter = '\u0000';
+		for (char c : expression.toCharArray()) {
+			if (c == '(') {
+				parenthesisWeight++;
+			} else if (c == ')') {
+				parenthesisWeight--;
+			} else {
+				// check if next character is the same (we don't accept "aa" or "a++b" for
+				// example)
+				if (previousCharacter == c) {
+					throw new IllegalArgumentException("The character " + c + " is duplicated");
+				}
+			}
+		}
+		if (parenthesisWeight != 0) {
+			throw new IllegalArgumentException("The number of parenthesis in the operation is not valid");
+		}
+	}
+
+	/**
+	 * Create the thompson automaton following the String expression. We will assume
+	 * that the expression is valid
+	 * 
+	 * @return the automaton that corresponds to the expression.
+	 */
+	public Automaton build() {
+		Stack<Automaton> stack = new Stack<>();
+
+		for (int i = 0; i < expression.length(); i++) {
+			char currentChar = expression.charAt(i);
+			if (isSpecialCharacter(currentChar)) {
+
+			}
+		}
+		
+		return null;
+	}
+
+	private boolean isSpecialCharacter(char character) {
+		// we have 5 characters that cannot be used in those expressions
+		return character == '(' || character == ')' || character == '+' || character == '.' || character == '*';
+	}
+}

--- a/src/test/unit/thompson/ParseAutomatonTest.java
+++ b/src/test/unit/thompson/ParseAutomatonTest.java
@@ -1,0 +1,41 @@
+package test.unit.thompson;
+
+import static org.junit.Assert.*;
+
+import java.text.ParseException;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import data.Automaton;
+import process.builders.ThompsonAutomatonBuilder;
+
+/**
+ * Tests to check the automaton resulting from multiple inputs.
+ * For now, only the number of states od each resulting automatons will be tested
+ * 
+ * @author Aldric Vitali Silvestre <aldric.vitali@outlook.fr>
+ */
+public class ParseAutomatonTest {
+	
+	@Test
+	public void testAutomaton1() throws ParseException {
+		final String INPUT_EXPRESSION = "(((a*)(b*))+(c(a+b)))";
+		Automaton automaton = automatonFromExpression(INPUT_EXPRESSION);
+		int numberOfStates = automaton.getNumberOfTotalStates();
+		assertEquals(16, numberOfStates);
+	}
+	
+	@Test
+	public void testAutomaton2() throws ParseException {
+		final String INPUT_EXPRESSION = "(((a*).(b*))+(c(d*)))";
+		Automaton automaton = automatonFromExpression(INPUT_EXPRESSION);
+		int numberOfStates = automaton.getNumberOfTotalStates();
+		assertEquals(14, numberOfStates);
+	}
+	
+	private Automaton automatonFromExpression(String expression) throws ParseException {
+		ThompsonAutomatonBuilder builder = new ThompsonAutomatonBuilder(expression);
+		return builder.build();
+	}
+}

--- a/src/test/unit/thompson/ThompsonAutomatonTestSuite.java
+++ b/src/test/unit/thompson/ThompsonAutomatonTestSuite.java
@@ -16,7 +16,9 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
 	LetterAutomatonTest.class,
 	ConcatenationAutomatonTest.class,
-	UnionAutomatonTest.class
+	UnionAutomatonTest.class,
+	StarAutomatonTest.class,
+	ParseAutomatonTest.class
 	})
 public class ThompsonAutomatonTestSuite {
 	


### PR DESCRIPTION
On peut (normalement) lire une expression du type  `"(((a*)(b*))+(c(a+b)))"` et avoi un automate fonctionnel (YOUPI !)

Deux tests unitaires qui comptent le nombre d'états de deux automates différents (ceux-ci marchent ben sûr). Bien sûr, je compte faire plus de tests à l'avenir, mais c'est très rassurant en tout cas.

Petite amélioration à voir cependant : il faut pour l'instant mettre BEAUCOUP de parenthèses, un système avec des priorités serait à envisager (même si le caractère de concaténation '.' peut être implicite) 